### PR TITLE
forward kwargs

### DIFF
--- a/seya/layers/attention.py
+++ b/seya/layers/attention.py
@@ -34,7 +34,7 @@ class SpatialTransformer(Layer):
                  downsample_factor=1,
                  return_theta=False,
                  **kwargs):
-        super(SpatialTransformer, self).__init__()
+        super(SpatialTransformer, self).__init__(**kwargs)
         self.downsample_factor = downsample_factor
         self.locnet = localization_net
         self.params = localization_net.params
@@ -210,7 +210,7 @@ class ST2(Layer):
                  downsample_factor=(1, 1),
                  return_theta=False,
                  **kwargs):
-        super(ST2, self).__init__()
+        super(ST2, self).__init__(**kwargs)
         self.ds = downsample_factor
         self.locnet = localization_net
         self.img_shape = img_shape

--- a/seya/layers/base.py
+++ b/seya/layers/base.py
@@ -66,8 +66,8 @@ class Replicator(MaskedLayer):
         Originally useful for broadcasting a fixed input into a scan loop.
         Think conditional RNNs without the need to rewrite the RNN class.
     '''
-    def __init__(self, leng):
-        super(Replicator, self).__init__()
+    def __init__(self, leng, **kwargs):
+        super(Replicator, self).__init__(kwargs)
         self.ones = T.ones((leng,))
         self.input = T.matrix()
 
@@ -86,8 +86,8 @@ class Unpool(Layer):
     ds: list with two values each one defines how much that dimension will
     be upsampled.
     '''
-    def __init__(self, ds):
-        super(Unpool, self).__init__()
+    def __init__(self, ds, **kwargs):
+        super(Unpool, self).__init__(kwargs)
         self.input = T.tensor4()
         self.ds = ds
 
@@ -98,10 +98,10 @@ class Unpool(Layer):
 
 
 class TimePicker(MaskedLayer):
-    def __init__(self, time=-1):
+    def __init__(self, time=-1, **kwargs):
         '''Picks a single value in time from a recurrent layer
            without forgeting its input mask'''
-        super(TimePicker, self).__init__()
+        super(TimePicker, self).__init__(kwargs)
         self.time = time
         self.input = T.tensor3()
 

--- a/seya/layers/coding.py
+++ b/seya/layers/coding.py
@@ -62,9 +62,10 @@ class SparseCoding(Layer):
                  n_steps=10,
                  return_reconstruction=False,
                  W_regularizer=None,
-                 activity_regularizer=None):
+                 activity_regularizer=None,
+                 **kwargs):
 
-        super(SparseCoding, self).__init__()
+        super(SparseCoding, self).__init__(kwargs)
         self.init = initializations.get(init)
         self.input_dim = input_dim
         self.output_dim = output_dim

--- a/seya/layers/containers.py
+++ b/seya/layers/containers.py
@@ -26,7 +26,8 @@ class Recursive(Layer):
             - get_weights
             - set_weights
     '''
-    def __init__(self, truncate_gradient=-1, return_sequences=False):
+
+    def __init__(self, truncate_gradient=-1, return_sequences=False, **kwargs):
         self.return_sequences = return_sequences
         self.truncate_gradient = truncate_gradient
         self.namespace = set()  # strings
@@ -50,6 +51,7 @@ class Recursive(Layer):
         self.updates = []
 
         self.states_map = {}
+        super(Recursive, self).__init__(**kwargs)
 
     @property
     def nb_input(self):

--- a/seya/layers/recurrent.py
+++ b/seya/layers/recurrent.py
@@ -16,8 +16,8 @@ def _get_reversed_input(self, train=False):
 
 class Bidirectional(Recurrent):
     def __init__(self, forward, backward, return_sequences=False,
-                 truncate_gradient=-1):
-        super(Bidirectional, self).__init__()
+                 truncate_gradient=-1, **kwargs):
+        super(Bidirectional, self).__init__(**kwargs)
         self.forward = forward
         self.backward = backward
         self.params = forward.params + backward.params

--- a/seya/layers/tensor.py
+++ b/seya/layers/tensor.py
@@ -16,8 +16,8 @@ class FDPCN(Recurrent):
                  init='glorot_uniform', inner_init='orthogonal',
                  activation='sigmoid', gate_activation='sigmoid',
                  weights=None, return_mode='states',
-                 truncate_gradient=-1, return_sequences=False):
-        super(FDPCN, self).__init__()
+                 truncate_gradient=-1, return_sequences=False, **kwargs):
+        super(FDPCN, self).__init__(kwargs)
         self.init = initializations.get(init)
         self.inner_init = initializations.get(inner_init)
         self.input_dim = input_dim


### PR DESCRIPTION
The new 0.2.0 keras version requires sometimes `input_shape` to be set.
Therefore it is important to forward the `**kwargs` argument to the Layer
constructor.